### PR TITLE
Simplified namespace

### DIFF
--- a/Sendy.Client.sln
+++ b/Sendy.Client.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SendyClient.Net", "src\SendyClient.Net.csproj", "{D086F38D-FE19-4BE6-9CAD-4DE573FFC228}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sendy.Client", "src\Sendy.Client.csproj", "{D086F38D-FE19-4BE6-9CAD-4DE573FFC228}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SendyClient.Net.Tests", "test\SendyClient.Net.Tests\SendyClient.Net.Tests.csproj", "{AF097020-1764-4F17-99F3-41E3CFDDE7F0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sendy.Client.Tests", "test\SendyClient.Net.Tests\Sendy.Client.Tests.csproj", "{AF097020-1764-4F17-99F3-41E3CFDDE7F0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Model/Campaign.cs
+++ b/src/Model/Campaign.cs
@@ -1,4 +1,4 @@
-﻿namespace SendyClient.Net.Model
+﻿namespace Sendy.Client.Model
 {
     public class Campaign
     {

--- a/src/Model/SendyResponse.cs
+++ b/src/Model/SendyResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace SendyClient.Net.Model
+﻿namespace Sendy.Client.Model
 {
     public class SendyResponse
     {

--- a/src/Sendy.Client.csproj
+++ b/src/Sendy.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <Description>A Sendy client, now supported on .Net Core!</Description>
     <Authors>Jeroen Klarenbeek</Authors>
     <Company />
@@ -11,6 +11,9 @@
     <RepositoryUrl>https://github.com/kloarubeek/SendyClient.Net</RepositoryUrl>
     <PackageTags>Sendy</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
+    <PackageId>SendyClient.Net</PackageId>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/SendyClient.cs
+++ b/src/SendyClient.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Threading.Tasks;
-using SendyClient.Net.Model;
-using static SendyClient.Net.SendyResponseHelper;
 using System.Runtime.CompilerServices;
-[assembly: InternalsVisibleTo("SendyClient.Net.Tests")]
+using System.Threading.Tasks;
+using Sendy.Client.Model;
 
-namespace SendyClient.Net
+[assembly: InternalsVisibleTo("Sendy.Client.Tests")]
+
+namespace Sendy.Client
 {
 	public class SendyClient : IDisposable
 	{
@@ -39,7 +39,7 @@ namespace SendyClient.Net
 
 			var result = await _httpClient.PostAsync("subscribe", subscribeData);
 
-			return await HandleResponse(result, SendyActions.Subscribe);
+			return await SendyResponseHelper.HandleResponse(result, SendyResponseHelper.SendyActions.Subscribe);
 		}
 
 		public async Task<SendyResponse> Unsubscribe(string emailAddress, string listId)
@@ -52,7 +52,7 @@ namespace SendyClient.Net
 
 			var result = await _httpClient.PostAsync("unsubscribe", subscribeData);
 
-			return await HandleResponse(result, SendyActions.Unsubscribe);
+			return await SendyResponseHelper.HandleResponse(result, SendyResponseHelper.SendyActions.Unsubscribe);
 		}
 
 		public async Task<SendyResponse> DeleteSubscriber(string emailAddress, string listId)
@@ -65,7 +65,7 @@ namespace SendyClient.Net
 
 			var result = await _httpClient.PostAsync("api/subscribers/delete.php", subscribeData);
 
-			return await HandleResponse(result, SendyActions.DeleteSubscriber);
+			return await SendyResponseHelper.HandleResponse(result, SendyResponseHelper.SendyActions.DeleteSubscriber);
 		}
 
 		public async Task<SendyResponse> SubscriptionStatus(string emailAddress, string listId)
@@ -78,7 +78,7 @@ namespace SendyClient.Net
 
 			var result = await _httpClient.PostAsync("api/subscribers/subscription-status.php", subscribeData);
 
-			return await HandleResponse(result, SendyActions.SubscriptionStatus);
+			return await SendyResponseHelper.HandleResponse(result, SendyResponseHelper.SendyActions.SubscriptionStatus);
 		}
 
 		public async Task<SendyResponse> ActiveSubscriberCount(string listId)
@@ -90,7 +90,7 @@ namespace SendyClient.Net
 
 			var result = await _httpClient.PostAsync("api/subscribers/active-subscriber-count.php", subscribeData);
 			//test return value
-			return await HandleResponse(result, SendyActions.ActiveSubscriberCount);
+			return await SendyResponseHelper.HandleResponse(result, SendyResponseHelper.SendyActions.ActiveSubscriberCount);
 		}
 
 		/// <param name="campaign"></param>
@@ -121,7 +121,7 @@ namespace SendyClient.Net
 
 			var result = await _httpClient.PostAsync("api/campaigns/create.php", subscribeData);
 
-			return await HandleResponse(result, SendyActions.CreateCampaign);
+			return await SendyResponseHelper.HandleResponse(result, SendyResponseHelper.SendyActions.CreateCampaign);
 		}
 
 		private List<KeyValuePair<string, string>> GetPostData()

--- a/src/SendyResponseHelper.cs
+++ b/src/SendyResponseHelper.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using SendyClient.Net.Model;
+using Sendy.Client.Model;
 
-namespace SendyClient.Net
+namespace Sendy.Client
 {
 	/// <summary>
 	/// The Sendy API has an interesting response system. We'd like to know if things were successful or not. This is only possible

--- a/test/SendyClient.Net.Tests/Sendy.Client.Tests.csproj
+++ b/test/SendyClient.Net.Tests/Sendy.Client.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\SendyClient.Net.csproj" />
+    <ProjectReference Include="..\..\src\Sendy.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SendyClient.Net.Tests/SendyClientActiveSubscriberCountTests.cs
+++ b/test/SendyClient.Net.Tests/SendyClientActiveSubscriberCountTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using RichardSzalay.MockHttp;
 using Xunit;
 
-namespace SendyClient.Net.Tests
+namespace Sendy.Client.Tests
 {
     public class SendyClientActiveSubscriberCountTests
 	{

--- a/test/SendyClient.Net.Tests/SendyClientCreateCampaignTests.cs
+++ b/test/SendyClient.Net.Tests/SendyClientCreateCampaignTests.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using RichardSzalay.MockHttp;
-using SendyClient.Net.Model;
+using Sendy.Client.Model;
 using Xunit;
 
-namespace SendyClient.Net.Tests
+namespace Sendy.Client.Tests
 {
     public class SendyClientCreateCampaignTests
 	{

--- a/test/SendyClient.Net.Tests/SendyClientDeleteSubscriberTests.cs
+++ b/test/SendyClient.Net.Tests/SendyClientDeleteSubscriberTests.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using RichardSzalay.MockHttp;
 using Xunit;
 
-namespace SendyClient.Net.Tests
+namespace Sendy.Client.Tests
 {
     public class SendyClientDeleteSubscriberTests
     {

--- a/test/SendyClient.Net.Tests/SendyClientSubscribeTests.cs
+++ b/test/SendyClient.Net.Tests/SendyClientSubscribeTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using RichardSzalay.MockHttp;
 using Xunit;
 
-namespace SendyClient.Net.Tests
+namespace Sendy.Client.Tests
 {
     public class SendyClientSubscribeTests
     {

--- a/test/SendyClient.Net.Tests/SendyClientSubscriptionStatusTests.cs
+++ b/test/SendyClient.Net.Tests/SendyClientSubscriptionStatusTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using RichardSzalay.MockHttp;
 using Xunit;
 
-namespace SendyClient.Net.Tests
+namespace Sendy.Client.Tests
 {
     public class SendyClientSubscriptionStatusTests
     {

--- a/test/SendyClient.Net.Tests/SendyClientUnsubscribeTests.cs
+++ b/test/SendyClient.Net.Tests/SendyClientUnsubscribeTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using RichardSzalay.MockHttp;
 using Xunit;
 
-namespace SendyClient.Net.Tests
+namespace Sendy.Client.Tests
 {
     public class SendyClientUnsubscribeTests
 	{


### PR DESCRIPTION
By removing .Net from the namespace, the client call to the SendyClient is easier.